### PR TITLE
#86: Remove deprecated helmet.featurePolicy call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](changelog),
 and this project adheres to [Semantic Versioning](semver).
 
-<!--
-## X.X.X - XXXX-XX-XX - XXXXXX
+## Unreleased
 
 ### Added
+- Install `feature-policy` module.
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+- Remove deprecated `helmet.featurePolicy()` call.
+
 ### Fixed
+- Set Feature Policy HTTP header by `feature-policy` module.
+
 ### Security
--->
 
 ## 1.3.0 - 2020-11-23 - Bulk delete
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
     "express-rate-limit": "^5.1.3",
+    "feature-policy": "^0.5.0",
     "helmet": "^3.22.0",
     "http-errors": "^1.7.3",
     "joi-password-complexity": "^4.1.0",

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -9,6 +9,7 @@ const app = express()
 const config = require('config')
 const compression = require('compression')
 const helmet = require('helmet')
+const featurePolicy = require('feature-policy')
 const { Liquid } = require('liquidjs')
 const engine = new Liquid()
 const path = require('path')
@@ -57,23 +58,6 @@ const helmetHeaders = {
       upgradeInsecureRequests: true
     }
   },
-  featurePolicy: {
-    features: {
-      geolocation: ["'none'"],
-      midi: ["'none'"],
-      notifications: ["'none'"],
-      push: ["'none'"],
-      syncXhr: ["'self'"],
-      microphone: ["'none'"],
-      camera: ["'none'"],
-      magnetometer: ["'none'"],
-      gyroscope: ["'none'"],
-      speaker: ["'none'"],
-      vibrate: ["'none'"],
-      fullscreen: ["'none'"],
-      payment: ["'none'"]
-    }
-  },
   frameguard: {
     action: 'deny'
   },
@@ -87,6 +71,29 @@ const helmetHeaders = {
   }
 }
 app.use(helmet(helmetHeaders)) // Set HTTP headers
+
+/**
+ * Set Feature Policy HTTP header.
+ *
+ * @since unreleased
+ */
+app.use(featurePolicy({
+  features: {
+    geolocation: ["'none'"],
+    midi: ["'none'"],
+    notifications: ["'none'"],
+    push: ["'none'"],
+    syncXhr: ["'self'"],
+    microphone: ["'none'"],
+    camera: ["'none'"],
+    magnetometer: ["'none'"],
+    gyroscope: ["'none'"],
+    speaker: ["'none'"],
+    vibrate: ["'none'"],
+    fullscreen: ["'none'"],
+    payment: ["'none'"]
+  }
+}))
 
 /**
  * Setup gzip compression


### PR DESCRIPTION
## Summary

`helmet.featurePolicy()` is deprecated as of [3.23.0](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#3230---2020-06-12). This call has been removed, and the Feature Policy HTTP header is now set by the `feature-policy` module.

## Issues

Closes #86

## Changelog

### Added
- Install `feature-policy` module.

### Removed
- Remove deprecated `helmet.featurePolicy()` call.

### Fixed
- Set Feature Policy HTTP header by `feature-policy` module.

## Checklist
- [ ] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme