### PR TITLE
#89: Disable submit button to prevent duplicate POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,20 @@ and this project adheres to [Semantic Versioning](semver).
 ### Removed
 
 ### Fixed
+- Disable submit button to prevent duplicate POST requests. [#89][#89]
 
 ### Security
 
 ## 1.3.1 - 2020-11-23 - Remove deprecated method call
 
 ### Added
-- Install `feature-policy` module.
+- Install `feature-policy` module. [#86][#86]
 
 ### Removed
-- Remove deprecated `helmet.featurePolicy()` call.
+- Remove deprecated `helmet.featurePolicy()` call. [#86][#86]
 
 ### Fixed
-- Set Feature Policy HTTP header by `feature-policy` module.
+- Set Feature Policy HTTP header by `feature-policy` module. [#86][#86]
 
 ## 1.3.0 - 2020-11-23 - Bulk delete
 
@@ -72,3 +73,5 @@ and this project adheres to [Semantic Versioning](semver).
 [changelog]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/spec/v2.0.0.html
 [#84]: https://github.com/Visual-Communications/fair-housing-pledge/issues/84
+[#86]: https://github.com/Visual-Communications/fair-housing-pledge/issues/86
+[#89]: https://github.com/Visual-Communications/fair-housing-pledge/issues/89

--- a/src/client/_assets/css/components/form.css
+++ b/src/client/_assets/css/components/form.css
@@ -116,12 +116,19 @@
     color: white;
     cursor: pointer;
     font-weight: 700;
+    min-width: 8.25rem;
     padding: 0.75em 1em 0.5em;
 
     &:hover,
     &:focus {
       background: hsl(238.2, 51.8%, 55%);
       padding: 0.75em 1em 0.5em;
+    }
+
+    &[disabled] {
+      background: hsl(238.2, 51.8%, 37.5%);
+      cursor: not-allowed;
+      opacity: 0.5;
     }
   }
 }

--- a/src/client/_assets/js/modules/pledges-and-certificates.js
+++ b/src/client/_assets/js/modules/pledges-and-certificates.js
@@ -456,6 +456,11 @@ function handleClick (event) {
 function handleSubmit (event) {
   event.preventDefault()
 
+  // Disable submit button to prevent duplicate POST requests.
+  const button = document.querySelector('[name="pledge"] [type="submit"]')
+  button.setAttribute('disabled', '');
+  button.textContent = 'Submitting...'
+
   // Send a Google Analytics event
   if (window.gtag) {
     window.gtag('event', 'sign_up', {


### PR DESCRIPTION
## Summary

Sometimes a user submits duplicate `POST` requests while submitting the Pledge form. This change disables the Submit button when the form is submitted, preventing multiple submissions.

## Issues

Closes #89

## Checklist
- [ ] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme