### PR TITLE
#100: Add pledges data to admin dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](semver).
 ## Unreleased
 
 ### Added
+- Add pledges data to admin dashboard. [#100][#100]
 
 ### Changed
 
@@ -133,6 +134,7 @@ and this project adheres to [Semantic Versioning](semver).
 [#89]: https://github.com/Visual-Communications/fair-housing-pledge/issues/89
 [#92]: https://github.com/Visual-Communications/fair-housing-pledge/issues/92
 [#93]: https://github.com/Visual-Communications/fair-housing-pledge/issues/93
+[#100]: https://github.com/Visual-Communications/fair-housing-pledge/issues/100
 [#102]: https://github.com/Visual-Communications/fair-housing-pledge/issues/102
 [#104]: https://github.com/Visual-Communications/fair-housing-pledge/issues/104
 [#105]: https://github.com/Visual-Communications/fair-housing-pledge/issues/105

--- a/src/client/_assets/css/components/admin.css
+++ b/src/client/_assets/css/components/admin.css
@@ -99,6 +99,19 @@
     }
   }
 
+  &__pledges {
+    margin: 0;
+
+    .admin__brands + & {
+      border-top: 0.25em solid $blue;
+    }
+
+    th:first-child,
+    td:first-child {
+      padding-left: $space;
+    }
+  }
+
   &__message > :last-child {
     margin-bottom: 0;
   }

--- a/src/server/admin/js/pledges.js
+++ b/src/server/admin/js/pledges.js
@@ -28,3 +28,68 @@ export async function getPledgesData () {
     return showMessage('error', error)
   }
 }
+
+/**
+ * Get pledges markup.
+ *
+ * @since unreleased
+ *
+ * @param  {array} pledges Array of pledge objects.
+ * @return {string}        Markup.
+ */
+export function getPledgesMarkup (pledges) {
+  try {
+    // Build pledges dashboard data.
+    const dashboardPledges = pledges.map(pledge => {
+      return {
+        'Name': `${pledge.firstName} ${pledge.lastName}`,
+        'Email': pledge.email,
+        // @todo: Rename brands.
+        'Brand': pledge.brand,
+        'Course': pledge.courseCompleted,
+      }
+    })
+
+    // Build the table.
+    const table = document.createElement('table')
+    table.classList.add('admin__pledges')
+
+    // Build and append table headers.
+    const thead = document.createElement('thead')
+    const tr = document.createElement('tr')
+    const headers = Object.keys(dashboardPledges[0])
+    headers.forEach(header => {
+      const th = document.createElement('th')
+      th.textContent = header
+      tr.appendChild(th)
+    })
+    thead.appendChild(tr)
+    table.appendChild(thead)
+
+    // Build and append table rows.
+    const tbody = document.createElement('tbody')
+    dashboardPledges.forEach(pledge => {
+      // Build the row.
+      const tr = document.createElement('tr')
+      Object.keys(pledge).forEach(cell => {
+        const td = document.createElement('td')
+        td.textContent = pledge[cell]
+        tr.appendChild(td)
+      })
+
+      // Append the row.
+      tbody.appendChild(tr)
+    })
+    table.appendChild(tbody)
+
+    // Build and return the markup.
+    const markup = document.createDocumentFragment()
+    markup.appendChild(table)
+    showMessage('message', markup)
+    return markup
+  }
+
+  catch (error) {
+    return showMessage('error', error)
+  }
+}

--- a/src/server/admin/js/render.js
+++ b/src/server/admin/js/render.js
@@ -1,5 +1,5 @@
 const { clearMessage } = require('./message')
-const { getPledgesData } = require('./pledges')
+const { getPledgesData, getPledgesMarkup } = require('./pledges')
 const { getSummaryData, getSummaryMarkup } = require('./summary')
 const { getDownloadMarkup } = require('./download')
 
@@ -9,16 +9,18 @@ const { getDownloadMarkup } = require('./download')
  * @since 2.0.0
  */
 export async function renderDashboard () {
-  // Get pledges and brands data.
-  const pledges = await getPledgesData()
-  const brands = getSummaryData(pledges)
+  // Get pledges and summary data.
+  const pledgesData = await getPledgesData()
+  const summaryData = getSummaryData(pledgesData)
 
   // Render the dashboard markup.
   const dashboard = document.querySelector('[data-admin="dashboard"]')
   const navigation = document.querySelector('.admin__nav-list')
-  const summary = getSummaryMarkup(brands)
+  const summary = getSummaryMarkup(summaryData)
+  const pledges = getPledgesMarkup(pledgesData)
   const download = getDownloadMarkup(['summary', 'pledges'])
   dashboard.appendChild(summary)
+  dashboard.appendChild(pledges)
   navigation.insertBefore(download, navigation.querySelector('[data-admin-nav="logout"]'))
 
   // Remove loading message.


### PR DESCRIPTION
## Summary

Stakeholders should be able to view all pledges while logged in. This change adds pledges data beneath brand summary data.

## Issue(s)

#100

## Changelog

### Added
- Add pledges data to admin dashboard. [#100]

## Screenshot(s)

<img width="1792" alt="add-pledges-data-to-admin-dashboard" src="https://user-images.githubusercontent.com/7530507/101283012-31879500-37a6-11eb-9a72-a7329f94e66d.png">

## Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated the Docs
- [ ] I have updated the Readme
