### PR TITLE
Remove CSP headers, add CSP report-only headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](semver).
 ## [Unreleased]
 
 ### Added
+- CSP report-only headers.
 
 ### Changed
+- Get form action URL from environment variable.
+- Clean up `getUrlParameter()` logic.
 
 ### Deprecated
 
 ### Removed
+- CSP headers.
 
 ### Fixed
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -109,13 +109,13 @@
 
   [headers.values]
     Access-Control-Allow-Origin = 'https://fairhousingpledge.com'
-    # Content-Security-Policy = '''
-    #   default-src 'self';
-    #   script-src 'self' https://*.cloudfront.net https://polyfill.io https://www.google-analytics.com;
-    #   style-src 'self' https://*.cloudfront.net;
-    #   img-src 'self' https://*.cloudfront.net;
-    #   font-src 'self' https://*.cloudfront.net;
-    #   upgrade-insecure-requests;'''
+    Content-Security-Policy-Report-Only = '''
+      default-src 'self';
+      script-src 'self' https://*.cloudfront.net https://polyfill.io https://www.google-analytics.com;
+      style-src 'self' https://*.cloudfront.net;
+      img-src 'self' https://*.cloudfront.net;
+      font-src 'self' https://*.cloudfront.net https://fonts.gstatic.com;
+      upgrade-insecure-requests;'''
     Feature-Policy = '''
       geolocation 'none';
       midi 'none';

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -37,7 +37,7 @@ if(!config.get('jwtPrivateKey')) {
 }
 
 /**
- * Setup HTTP headers
+ * Set HTTP headers.
  */
 
 // CORS
@@ -47,15 +47,31 @@ const corsOptions = {
 }
 app.use(cors(corsOptions))
 
-// Helmet
+// Set HTTP headers with Helmet.
+const thisOrigin = isProduction ? "'self'" : `'self' ${config.get('site.url')}`
 const helmetHeaders = {
   contentSecurityPolicy: {
     directives: {
       defaultSrc: [
-        isProduction ? "'self'" : `'self' ${config.get('site.url')}`
+        "'none'",
+      ],
+      scriptSrc: [
+        thisOrigin,
+        "'unsafe-inline'"
+      ],
+      styleSrc: [
+        thisOrigin,
+      ],
+      imgSrc: [
+        thisOrigin,
+      ],
+      fontSrc: [
+        thisOrigin,
+        'https://fonts.gstatic.com'
       ],
       upgradeInsecureRequests: true
-    }
+    },
+    reportOnly: true
   },
   frameguard: {
     action: 'deny'
@@ -69,7 +85,7 @@ const helmetHeaders = {
     policy: 'strict-origin-when-cross-origin'
   }
 }
-app.use(helmet(helmetHeaders)) // Set HTTP headers
+app.use(helmet(helmetHeaders))
 
 /**
  * Set Feature Policy HTTP header.


### PR DESCRIPTION
## Summary

I'm temporarily removing all CSP headers and adding report-only CSP headers for troubleshooting and debugging.

## Testing

Navigate the site and the admin dashboard, and confirm there are no CSP errors.

## Issue(s)

N/A

## Changelog

### Added
- CSP report-only headers.

### Removed
- CSP headers.

## Screenshot(s)

N/A

## Release Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated any `@since unreleased` docblock comments
- [ ] I have run `npm version [major | minor | patch]`
- [ ] I have updated the Docs
- [ ] I have updated the Readme
