### PR TITLE
hotfix: Build minified JS in production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -303,6 +303,7 @@ function js () {
   const merged = merge(clientJs, adminJs)
   return merged.isEmpty() ? null : merged
 }
+exports.js = js
 
 function minifyHtml () {
   return gulp.src(paths.html.output)
@@ -339,13 +340,30 @@ function minifyCss () {
 }
 
 function minifyJs () {
-  return gulp.src(paths.js.output)
-    .pipe(sourcemaps.init())
-    .pipe(uglify()) // Minify
-    .pipe(rename({ suffix: '.min' })) // Rename
-    .pipe(sourcemaps.write('.')) // Maintain Sourcemaps
-    .pipe(gulp.dest(paths.js.dest))
+
+  const merged = merge(
+    // Website client JS.
+    gulp.src([
+      `./${BUILD}/js/**.js`,
+    ])
+      .pipe(sourcemaps.init())
+      .pipe(uglify()) // Minify
+      .pipe(rename({ suffix: '.min' })) // Rename
+      .pipe(sourcemaps.write('.')) // Maintain Sourcemaps
+      .pipe(gulp.dest(paths.js.dest)),
+
+    // Admin client JS.
+    gulp.src([paths.js.admin.output])
+      .pipe(sourcemaps.init())
+      .pipe(uglify()) // Minify
+      .pipe(rename({ suffix: '.min' })) // Rename
+      .pipe(sourcemaps.write('.')) // Maintain Sourcemaps
+      .pipe(gulp.dest(paths.js.admin.dest))
+  )
+
+  return merged.isEmpty() ? null : merged
 }
+exports.minifyJs = minifyJs
 
 function minifySvg () {
   return gulp.src(paths.svg.output)

--- a/netlify.toml
+++ b/netlify.toml
@@ -111,7 +111,7 @@
     Access-Control-Allow-Origin = 'https://fairhousingpledge.com'
     Content-Security-Policy-Report-Only = '''
       default-src 'none';
-      script-src 'self' https://*.cloudfront.net https://polyfill.io https://www.google-analytics.com;
+      script-src 'self' https://*.cloudfront.net https://cdnjs.cloudflare.com https://polyfill.io https://www.google-analytics.com https://www.googletagmanager.com;
       style-src 'self' https://*.cloudfront.net;
       img-src 'self' https://*.cloudfront.net;
       font-src 'self' https://*.cloudfront.net https://fonts.gstatic.com;


### PR DESCRIPTION
JS files in `/js` and `/js/admin` have the same name: `bundle.js` in development and `bundle.min.js` in production. The `minifyJs` function in the build pipeline was getting confused and overwriting one with the other, which resulted in the main JS file getting deleted during build. This is fixed by handling them in separate Gulp pipelines, which the function now merges and returns.

I also added some 3rd-party CDN origins to the CSP-report-only header.

## Release Checklist
- [x] I have tested this code
- [ ] I have updated the Changelog
- [ ] I have updated any `@since unreleased` docblock comments
- [ ] I have run `npm version [major | minor | patch]`
- [ ] I have updated the Docs
- [ ] I have updated the Readme
