### PR TITLE
[#135]: Sort admin dashboard dates correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](semver).
 ### Removed
 
 ### Fixed
+- Sort admin dashboard dates correctly. [#135]
 
 ### Security
 

--- a/src/server/admin/js/classes/Dashboard.js
+++ b/src/server/admin/js/classes/Dashboard.js
@@ -468,11 +468,17 @@ export class Dashboard {
     const sorted = data[trigger]
       .sort((a, b) => {
         // @todo: Toggle asc/desc on click.
-        if (typeof a[sortBy] === 'string' || a[sortBy] instanceof String) {
+        if (
+          sortBy !== 'date' &&
+          (typeof a[sortBy] === 'string' || a[sortBy] instanceof String)
+        ) {
           // Ascending order.
           return a[sortBy] > b[sortBy] ? 1 : -1
         } else {
           // Descending order.
+          if (sortBy === 'date') {
+            return new Date(a[sortBy]) < new Date(b[sortBy]) ? 1 : -1  
+          }
           return a[sortBy] < b[sortBy] ? 1 : -1
         }
       })


### PR DESCRIPTION
## Summary
Admin dashboard dates were sorted alphabetically as strings. This resulted in 1/1/2021 coming first instead of the most recent date. Date sorting is now handled as dates instead of strings, and sorted in descending order.

## Testing
- Login to `/admin`
- Sort pledges by date
- Verify that they're sorted descending from most recent to least recent

## Issue(s)
Closes #135

## Changelog

### Fixed
- Sort admin dashboard dates correctly. [#135]

## Release Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated any `@since unreleased` docblock comments
- [ ] I have run `npm version [major | minor | patch]`
- [ ] I have updated the Docs
- [ ] I have updated the Readme
