### PR TITLE
hotfix: Add Google Analytics tracking and script bundle to 2021 courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](semver).
 ### Removed
 
 ### Fixed
+- Add Google Analytics tracking and script bundle to 2021 courses.
 
 ### Security
 

--- a/src/client/_content/courses/2021/areaa/story.html
+++ b/src/client/_content/courses/2021/areaa/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>AREAA The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>AREAA The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: '6d107e1d-bfe1-4947-babc-91566d1a1d1e',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: '6d107e1d-bfe1-4947-babc-91566d1a1d1e',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">AREAA The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">AREAA The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/bhgre/story.html
+++ b/src/client/_content/courses/2021/bhgre/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.50.24668.0 -->
-  <title>BHGRE The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.50.24668.0 -->
+    <title>BHGRE The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'ModernPlayerRefresh,MultipleQuizTracking,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.50.24668.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'ModernPlayerRefresh,MultipleQuizTracking,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.50.24668.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">BHGRE The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">BHGRE The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/century-21/story.html
+++ b/src/client/_content/courses/2021/century-21/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>C21 The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>C21 The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">C21 The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">C21 The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/coldwell-banker/story.html
+++ b/src/client/_content/courses/2021/coldwell-banker/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>CB The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>CB The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">CB The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">CB The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/corcoran/story.html
+++ b/src/client/_content/courses/2021/corcoran/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>Corcoran The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>Corcoran The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">Corcoran The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">Corcoran The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/era/story.html
+++ b/src/client/_content/courses/2021/era/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.50.24668.0 -->
-  <title>ERA The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.50.24668.0 -->
+    <title>ERA The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'ModernPlayerRefresh,MultipleQuizTracking,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.50.24668.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'ModernPlayerRefresh,MultipleQuizTracking,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.50.24668.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">ERA The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">ERA The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/lgbtq/story.html
+++ b/src/client/_content/courses/2021/lgbtq/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>LGBTQ The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>LGBTQ The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">LGBTQ The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">LGBTQ The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/nahrep/story.html
+++ b/src/client/_content/courses/2021/nahrep/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.50.24668.0 -->
-  <title>NAHREP The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.50.24668.0 -->
+    <title>NAHREP The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'ModernPlayerRefresh,MultipleQuizTracking,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.50.24668.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'ModernPlayerRefresh,MultipleQuizTracking,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.50.24668.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">NAHREP The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">NAHREP The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/nammba/story.html
+++ b/src/client/_content/courses/2021/nammba/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>NAMMBA The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>NAMMBA The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">NAMMBA The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">NAMMBA The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/nareb/story.html
+++ b/src/client/_content/courses/2021/nareb/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>NAREB The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>NAREB The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">NAREB The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">NAREB The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/realogy/story.html
+++ b/src/client/_content/courses/2021/realogy/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>Realogy The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>Realogy The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">Realogy The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">Realogy The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>

--- a/src/client/_content/courses/2021/sir/story.html
+++ b/src/client/_content/courses/2021/sir/story.html
@@ -1,138 +1,127 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <!-- Created using Storyline 360 - http://www.articulate.com  -->
-  <!-- version: 3.49.24347.0 -->
-  <title>SIR The Promise to Deliver Fair Housing</title>
-  <meta http-equiv="x-ua-compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
-  <meta name="apple-mobile-web-app-capable" content="yes" />
-  <style>
+  <head>
+    <meta charset="utf-8">
+    <!-- Created using Storyline 360 - http://www.articulate.com  -->
+    <!-- version: 3.49.24347.0 -->
+    <title>SIR The Promise to Deliver Fair Housing</title>
+    <meta http-equiv="x-ua-compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, shrink-to-fit=no, minimal-ui" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <style>
     html, body { height: 100%; padding: 0; margin: 0 }
     #app { height: 100%; width: 100%; }
-  </style>
-  
-  <script>window.THREE = { };</script>
-</head>
-<body style="background: #282828" class="cs-HTML theme-unified">
-  <!-- 360 -->
-  <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
+    </style>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-164050142-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-164050142-1');
+    </script>
+    
+    <script>window.THREE = { };</script>
+  </head>
+  <body style="background: #282828" class="cs-HTML theme-unified">
+    <!-- 360 -->
+    <script>!function(e){function n(e,i){return e.test(i)}function i(e){var i=e||navigator.userAgent,o=i.split("[FBAN");if(void 0!==o[1]&&(i=o[0]),this.apple={phone:n(t,i),ipod:n(d,i),tablet:!n(t,i)&&n(s,i),device:n(t,i)||n(d,i)||n(s,i)},this.amazon={phone:n(h,i),tablet:!n(h,i)&&n(a,i),device:n(h,i)||n(a,i)},this.android={phone:n(h,i)||n(b,i),tablet:!n(h,i)&&!n(b,i)&&(n(a,i)||n(r,i)),device:n(h,i)||n(a,i)||n(b,i)||n(r,i)},this.windows={phone:n(l,i),tablet:n(p,i),device:n(l,i)||n(p,i)},this.other={blackberry:n(f,i),blackberry10:n(u,i),opera:n(c,i),firefox:n(A,i),chrome:n(w,i),device:n(f,i)||n(u,i)||n(c,i)||n(A,i)||n(w,i)},this.seven_inch=n(v,i),this.any=this.apple.device||this.android.device||this.windows.device||this.other.device||this.seven_inch,this.phone=this.apple.phone||this.android.phone||this.windows.phone,this.tablet=this.apple.tablet||this.android.tablet||this.windows.tablet,"undefined"==typeof window)return this}function o(){var e=new i;return e.Class=i,e}var t=/iPhone/i,d=/iPod/i,s=/iPad/i,b=/(?=.*\bAndroid\b)(?=.*\bMobile\b)/i,r=/Android/i,h=/(?=.*\bAndroid\b)(?=.*\bSD4930UR\b)/i,a=/(?=.*\bAndroid\b)(?=.*\b(?:KFOT|KFTT|KFJWI|KFJWA|KFSOWI|KFTHWI|KFTHWA|KFAPWI|KFAPWA|KFARWI|KFASWI|KFSAWI|KFSAWA)\b)/i,l=/IEMobile/i,p=/(?=.*\bWindows\b)(?=.*\bARM\b)/i,f=/BlackBerry/i,u=/BB10/i,c=/Opera Mini/i,w=/(CriOS|Chrome)(?=.*\bMobile\b)/i,A=/(?=.*\bFirefox\b)(?=.*\bMobile\b)/i,v=new RegExp("(?:Nexus 7|BNTV250|Kindle Fire|Silk|GT-P1000)","i");"undefined"!=typeof module&&module.exports&&"undefined"==typeof window?module.exports=i:"undefined"!=typeof module&&module.exports&&"undefined"!=typeof window?module.exports=o():"function"==typeof define&&define.amd?define("isMobile",[],e.isMobile=o()):e.isMobile=o()}(this);
     window.isMobile.apple.tablet = window.isMobile.apple.tablet ||
-      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     window.isMobile.apple.device = window.isMobile.apple.device || window.isMobile.apple.tablet;
     window.isMobile.tablet = window.isMobile.tablet || window.isMobile.apple.tablet;
     window.isMobile.any = window.isMobile.any || window.isMobile.apple.tablet;
-  </script>
-
-  <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
-
-  <div id="preso"></div>
-  <script>
+    </script>
+    <div id="focus-sink" aria-hidden="true" tabIndex="-1"></div>
+    <div id="preso"></div>
+    <script>
     window.DS = {};
     window.globals = {
-      DATA_PATH_BASE: '',
-      HAS_FRAME: true,
-      HAS_SLIDE: true,
-
-      lmsPresent: false,
-      tinCanPresent: false,
-      cmi5Present: false,
-      aoSupport: false,
-      scale: 'noscale',
-      captureRc: false,
-      browserSize: 'optimal',
-      bgColor: '#282828',
-      features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
-      themeName: 'unified',
-      preloaderColor: '#FFFFFF',
-      suppressAnalytics: false,
-      productChannel: 'stable',
-      publishSource: 'storyline',
-      aid: 'auth0|5be1c4d7548d8e55b457e8db',
-      cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
-      playerVersion: '3.49.24347.0',
-      maxIosVideoElements: 5,
-
-      
-      parseParams: function(qs) {
-        if (window.globals.parsedParams != null) {
-          return window.globals.parsedParams;
-        }
-        qs = (qs || window.location.search.substr(1)).split('+').join(' ');
-        var params = {},
-            tokens,
-            re = /[?&]?([^=]+)=([^&]*)/g;
-
-        while (tokens = re.exec(qs)) {
-          params[decodeURIComponent(tokens[1]).trim()] =
-            decodeURIComponent(tokens[2]).trim();
-        }
-        window.globals.parsedParams = params;
-        return params;
-      }
-
+    DATA_PATH_BASE: '',
+    HAS_FRAME: true,
+    HAS_SLIDE: true,
+    lmsPresent: false,
+    tinCanPresent: false,
+    cmi5Present: false,
+    aoSupport: false,
+    scale: 'noscale',
+    captureRc: false,
+    browserSize: 'optimal',
+    bgColor: '#282828',
+    features: 'AccessibleText,MultipleQuizTracking,SettingsControl,TextStyleHyperlinks',
+    themeName: 'unified',
+    preloaderColor: '#FFFFFF',
+    suppressAnalytics: false,
+    productChannel: 'stable',
+    publishSource: 'storyline',
+    aid: 'auth0|5be1c4d7548d8e55b457e8db',
+    cid: 'f170c916-1042-4a66-85a2-07e9f75a82fc',
+    playerVersion: '3.49.24347.0',
+    maxIosVideoElements: 5,
+    
+    parseParams: function(qs) {
+    if (window.globals.parsedParams != null) {
+    return window.globals.parsedParams;
+    }
+    qs = (qs || window.location.search.substr(1)).split('+').join(' ');
+    var params = {},
+    tokens,
+    re = /[?&]?([^=]+)=([^&]*)/g;
+    while (tokens = re.exec(qs)) {
+    params[decodeURIComponent(tokens[1]).trim()] =
+    decodeURIComponent(tokens[2]).trim();
+    }
+    window.globals.parsedParams = params;
+    return params;
+    }
     };
-
     (function() {
-
-      var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
-
-      var addDeviceClasses = function(prefix, testObj) {
-        var curr, i;
-        for (i = 0; i < classTypes.length; i++) {
-          curr = classTypes[i];
-          if (testObj[curr]) {
-            document.body.classList.add(prefix + curr);
-          }
-        }
-      };
-
-      var params = window.globals.parseParams(),
-          isDevicePreview = params.devicepreview === '1',
-          isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
-          isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
-          isMobileOverride = isPhoneOverride || isTabletOverride;
-
-      var deviceView = {
-        desktop: !window.isMobile.any && !isMobileOverride,
-        mobile: window.isMobile.any || isMobileOverride,
-        phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
-        tablet: isTabletOverride || window.isMobile.tablet
-      };
-
-      window.globals.deviceView = deviceView;
-      window.isMobile.desktop = !window.isMobile.any;
-      window.isMobile.mobile = window.isMobile.any;
-
-      addDeviceClasses('view-', deviceView);
-
+    var classTypes = [ 'desktop', 'mobile', 'phone', 'tablet' ];
+    var addDeviceClasses = function(prefix, testObj) {
+    var curr, i;
+    for (i = 0; i < classTypes.length; i++) {
+    curr = classTypes[i];
+    if (testObj[curr]) {
+    document.body.classList.add(prefix + curr);
+    }
+    }
+    };
+    var params = window.globals.parseParams(),
+    isDevicePreview = params.devicepreview === '1',
+    isPhoneOverride = params.deviceType === 'phone' || (isDevicePreview && params.phone == '1'),
+    isTabletOverride = (params.deviceType === 'tablet' || isDevicePreview) && !isPhoneOverride,
+    isMobileOverride = isPhoneOverride || isTabletOverride;
+    var deviceView = {
+    desktop: !window.isMobile.any && !isMobileOverride,
+    mobile: window.isMobile.any || isMobileOverride,
+    phone: isPhoneOverride || (window.isMobile.phone && !isTabletOverride),
+    tablet: isTabletOverride || window.isMobile.tablet
+    };
+    window.globals.deviceView = deviceView;
+    window.isMobile.desktop = !window.isMobile.any;
+    window.isMobile.mobile = window.isMobile.any;
+    addDeviceClasses('view-', deviceView);
     })();
-  </script>
-  
-  <script src='story_content/user.js' type=text/javascript></script>
-  <div class="slide-loader"></div>
-
-  <script type="text/javascript">
+    </script>
+    
+    <script src='story_content/user.js' type=text/javascript></script>
+    <div class="slide-loader"></div>
+    <script type="text/javascript">
     var doc = document, loader = doc.body.querySelector('.slide-loader'); [ 1, 2, 3 ].forEach(function(n) { var d = doc.createElement('div'); d.style.backgroundColor = window.globals.preloaderColor; d.classList.add('mobile-loader-dot'); d.classList.add('dot' + n); loader.appendChild(d); });
-  </script>
-
-  <div class="mobile-load-title-overlay" style="display: none">
-    <div class="mobile-load-title">SIR The Promise to Deliver Fair Housing</div>
-  </div>
-
-  <div class="mobile-chrome-warning"></div>
-
-  <script>
+    </script>
+    <div class="mobile-load-title-overlay" style="display: none">
+      <div class="mobile-load-title">SIR The Promise to Deliver Fair Housing</div>
+    </div>
+    <div class="mobile-chrome-warning"></div>
+    <script>
     
     if (window.autoSpider && window.vInterfaceObject) {
-      document.querySelector('.mobile-load-title-overlay').style.display = 'none';
+    document.querySelector('.mobile-load-title-overlay').style.display = 'none';
     }
-  </script>
-
-  
-
-  <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
-</body>
-<script src="html5/lib/scripts/bootstrapper.min.js"></script>
+    </script>
+    
+    <link rel="stylesheet" href="html5/data/css/output.min.css" data-noprefix />
+  </body>
+  <script src="html5/lib/scripts/bootstrapper.min.js"></script>
+  <script src="/js/bundle.min.js"></script>
 </html>


### PR DESCRIPTION
## Summary
2021 courses do not have Google Analytics tracking or the client script bundle. As a result, activity is not tracked in Google Analytics, and when a user completes a course and fills out the pledge form, it doesn't track that they completed a course.
## Testing
Complete a 2021 course, fill out the pledge form, and confirm that `courseCompleted` is set to `true`
## Issue(s)
N/A
## Changelog
### Fixed
- Add Google Analytics tracking and script bundle to 2021 courses.

## Screenshot(s)
N/A
## Release Checklist
- [ ] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated any `@since unreleased` docblock comments
- [ ] I have run `npm version [major | minor | patch]`
- [ ] I have updated the Docs
- [ ] I have updated the Readme
