### PR TITLE
feature: Add Cartus and other organizations to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](semver).
 ## [Unreleased]
 
 ### Added
+- Add Cartus and other organizations to dashboard.
 
 ### Changed
 
@@ -15,6 +16,8 @@ and this project adheres to [Semantic Versioning](semver).
 ### Removed
 
 ### Fixed
+- Don't pre-fill brand field since query param does not match select values.
+- Show Realogy certificate if brand is unrecognized.
 
 ### Security
 

--- a/src/client/_assets/js/modules/pledges-and-certificates.js
+++ b/src/client/_assets/js/modules/pledges-and-certificates.js
@@ -270,10 +270,6 @@ function handleLoad () {
   // If there is no brand, we're done
   if (!storage.brand) return false
   
-  // Pre-fill Brand field
-  const brandInput = document.querySelector('#brand')
-  if (brandInput) brandInput.value = storage.brand
-
   // If the pledge hasn't been filled out yet, we're done
   if (!storage.pledge) return false
 
@@ -388,8 +384,11 @@ function loadCertificate (brand, pledge) {
     }
   }
 
+  // In case of unrecognized brand, use Realogy.
+  const certificateBrand = brands.hasOwnProperty(brand) ? brand : 'Realogy'
+
   // Add brand certificate class
-  body.classList.add(`certificate_${brands[brand].class}`)
+  body.classList.add(`certificate_${brands[certificateBrand].class}`)
 
   // Get today's date and setup month names
   const date = new Date()
@@ -406,14 +405,14 @@ function loadCertificate (brand, pledge) {
     <p>to certify that they have completed to<br />
     satisfaction the Fair Housing Course.</p>
     <p>Granted ${monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}</p>
-    <img class="certificate__signature" src="${brands[brand].executive.signature}" alt="${brands[brand].executive.name}">
-    <p>${brands[brand].executive.name}<br />
-    ${brands[brand].executive.title}<br />
-    ${brands[brand].executive.company}</p>
-    <img class="certificate__logo" src="${brands[brand].logo}" alt="${brand}">
+    <img class="certificate__signature" src="${brands[certificateBrand].executive.signature}" alt="${brands[certificateBrand].executive.name}">
+    <p>${brands[certificateBrand].executive.name}<br />
+    ${brands[certificateBrand].executive.title}<br />
+    ${brands[certificateBrand].executive.company}</p>
+    <img class="certificate__logo" src="${brands[certificateBrand].logo}" alt="${certificateBrand}">
   </main>
   <footer class="certificate__footer pad">
-    <p class="certificate__disclaimer">${brands[brand].disclaimer}</p>
+    <p class="certificate__disclaimer">${brands[certificateBrand].disclaimer}</p>
   </footer>`
 }
 

--- a/src/server/admin/js/classes/Dashboard.js
+++ b/src/server/admin/js/classes/Dashboard.js
@@ -131,11 +131,17 @@ export class Dashboard {
     try {
       // Build brands pledges data and store in localStorage.
       const brands = {
+        areaa: { pledgesData: this.getPledgesBrand('AREAA') },
         bhgre: { pledgesData: this.getPledgesBrand('Better Homes') },
+        cartus: { pledgesData: this.getPledgesBrand('Cartus') },
         c21: { pledgesData: this.getPledgesBrand('Century') },
         cb: { pledgesData: this.getPledgesBrand('Coldwell Banker') },
         corcoran: { pledgesData: this.getPledgesBrand('Corcoran') },
         era: { pledgesData: this.getPledgesBrand('ERA') },
+        lgbtq: { pledgesData: this.getPledgesBrand('LGBTQ') },
+        nahrep: { pledgesData: this.getPledgesBrand('NAHREP') },
+        nammba: { pledgesData: this.getPledgesBrand('NAMMBA') },
+        nareb: { pledgesData: this.getPledgesBrand('NAREB') },
         other: { pledgesData: this.getPledgesBrand('Other') },
         realogy: { pledgesData: this.getPledgesBrand('Realogy Corporate') },
         rtg: { pledgesData: this.getPledgesBrand('Realogy Title Group') },
@@ -144,7 +150,9 @@ export class Dashboard {
       }
 
       Object.keys(brands).forEach(brand => {
-        brands[brand].brand = brands[brand].pledgesData[0].brand
+        brands[brand].brand = brands[brand].pledgesData.length
+          ? brands[brand].pledgesData[0]?.brand
+          : brand
         brands[brand].pledges = brands[brand].pledgesData.length
         brands[brand].course = brands[brand].pledgesData
           .filter(pledge => pledge.courseCompleted === 'true')
@@ -154,11 +162,12 @@ export class Dashboard {
         delete brands[brand].pledgesData
       })
 
-      // Update brand brands.
+      // Shorten long brand names for the dashboard.
       brands.bhgre.brand = 'BHGRE'
       brands.c21.brand = 'Century 21'
       brands.cb.brand = 'Coldwell Banker'
       brands.era.brand = 'ERA'
+      brands.lgbtq.brand = 'LGBTQ+'
       brands.sir.brand = 'Sotheby\'s'
       brands.total.brand = 'Total'
 


### PR DESCRIPTION
## Changelog
### Added
- Add Cartus and other organizations to dashboard.

### Fixed
- Don't pre-fill brand field since query param does not match select values.
- Show Realogy certificate if brand is unrecognized.
## Screenshot(s)
N/A
## Release Checklist
- [x] I have tested this code
- [x] I have updated the Changelog
- [ ] I have updated any `@since unreleased` docblock comments
- [ ] I have run `npm version [major | minor | patch]`
- [ ] I have updated the Docs
- [ ] I have updated the Readme
